### PR TITLE
Fix 6-hour cache and loading behavior

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,8 +15,8 @@ const config = {
   cacheComponents: true,
   experimental: {
     staleTimes: {
-      dynamic: 3600, // Cache dynamic pages for 1 hour (3600 seconds)
-      static: 3600, // Cache static pages for 1 hour (3600 seconds)
+      dynamic: 21600,
+      static: 21600,
     },
   },
   turbopack: {

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     "cheerio": "^1.1.0",
     "i": "^0.3.7",
     "igdb-api-node": "^5.0.2",
-    "next": "16.0.7",
+    "next": "16.1.6",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "typescript": "^5.8.3",
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@next/eslint-plugin-next": "15.1.3",
+    "@next/eslint-plugin-next": "16.1.6",
     "@types/eslint": "^8.56.12",
     "@typescript-eslint/eslint-plugin": "^8.37.0",
     "@typescript-eslint/parser": "^8.37.0",

--- a/src/app/[console]/[type]/actions.tsx
+++ b/src/app/[console]/[type]/actions.tsx
@@ -2,22 +2,27 @@
 
 import { cacheLife, cacheTag } from "next/cache";
 import { Consoles, Types } from "~/data/constants";
-import { fetchGamesIGDB, GameData } from "~/lib/igdb/client";
+import { fetchGamesIGDB } from "~/lib/igdb/client";
+import type { GameData } from "~/lib/igdb/client";
 
-export type { GameData };
+const SIX_HOURS_IN_SECONDS = 6 * 60 * 60;
 
 /**
  * Server action for fetching games from IGDB with caching
- * This provides an additional caching layer on top of fetch-level caching
- * The timestamp is passed as a parameter to make it part of the cache key
+ * This provides a 6-hour cache window for each console/type pair
  */
 export const fetchGames = async (
   c: Consoles,
   t: Types,
-  currentTime: number = Math.floor(Date.now() / 1000),
 ): Promise<GameData[]> => {
   "use cache";
-  cacheLife("hours");
+
+  cacheLife({
+    stale: SIX_HOURS_IN_SECONDS,
+    revalidate: SIX_HOURS_IN_SECONDS,
+    expire: SIX_HOURS_IN_SECONDS + 60,
+  });
   cacheTag(`igdb-${c}-${t}`);
-  return fetchGamesIGDB(c, t, currentTime);
+
+  return fetchGamesIGDB(c, t);
 };

--- a/src/app/[console]/[type]/loading.tsx
+++ b/src/app/[console]/[type]/loading.tsx
@@ -1,4 +1,18 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
 export default function Loading() {
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  if (!isHydrated) {
+    return null;
+  }
+
   const widths = ["w-20", "w-52", "w-32", "w-28", "w-40"];
   return (
     <ul className="-my-1.5">

--- a/src/app/[console]/[type]/page.tsx
+++ b/src/app/[console]/[type]/page.tsx
@@ -4,6 +4,8 @@ import { fetchGames } from "./actions";
 import { GameListItem } from "./components/GameListItem";
 import { dateToRelative } from "~/lib/utils/date";
 
+const SIX_HOURS_IN_SECONDS = 6 * 60 * 60;
+
 // Generate static params for all console/type combinations
 // This tells Next.js to prerender these routes at build time
 export function generateStaticParams() {
@@ -18,19 +20,20 @@ export function generateStaticParams() {
   );
 }
 
-export default async function ListPage(props: {
-  params: Promise<{
-    console: string;
-    type: string;
-  }>;
+async function CachedGameList({
+  selectedConsole,
+  selectedType,
+}: {
+  selectedConsole: Consoles;
+  selectedType: Types;
 }) {
   "use cache";
 
-  const params = await props.params;
-  const selectedConsole = params.console as Consoles;
-  const selectedType = params.type as Types;
-
-  cacheLife("hours");
+  cacheLife({
+    stale: SIX_HOURS_IN_SECONDS,
+    revalidate: SIX_HOURS_IN_SECONDS,
+    expire: SIX_HOURS_IN_SECONDS + 60,
+  });
   cacheTag(`list-${selectedConsole}-${selectedType}`);
 
   const games = await fetchGames(selectedConsole, selectedType);
@@ -53,5 +56,23 @@ export default async function ListPage(props: {
         />
       ))}
     </ul>
+  );
+}
+
+export default async function ListPage(props: {
+  params: Promise<{
+    console: string;
+    type: string;
+  }>;
+}) {
+  const params = await props.params;
+  const selectedConsole = params.console as Consoles;
+  const selectedType = params.type as Types;
+
+  return (
+    <CachedGameList
+      selectedConsole={selectedConsole}
+      selectedType={selectedType}
+    />
   );
 }


### PR DESCRIPTION
## Summary

Fixes stale cache-key behavior and loading fallback flashes so game lists stay cached for six hours across both data and rendered RSC output.

The previous `use cache` usage included request-time values in the cached function path, which could trigger unnecessary regeneration and expose the skeleton on visits that should have served cached content.

## Changes

- Upgrade Next.js to `16.1.6` and align `@next/eslint-plugin-next`
- Remove time-based cache-key inputs from game-fetch caching and set explicit 6-hour `cacheLife` in the server action
- Cache the rendered game list in a dedicated cached component keyed by stable route params with 6-hour `cacheLife`
- Update router `staleTimes` to 6 hours to match desired cache window
- Gate the loading skeleton behind hydration so it only shows during client-side navigation/loading

## Notes

Validated with `bun run build`; output confirms `/[console]/[type]` revalidate/expire at ~6h.