### PR TITLE
fix: show loading skeleton on cold route transitions

### DIFF
--- a/src/app/[console]/[type]/actions.tsx
+++ b/src/app/[console]/[type]/actions.tsx
@@ -1,5 +1,3 @@
-"use server";
-
 import { cacheLife, cacheTag } from "next/cache";
 import { Consoles, Types } from "~/data/constants";
 import { fetchGamesIGDB, GameData } from "~/lib/igdb/client";
@@ -7,9 +5,7 @@ import { fetchGamesIGDB, GameData } from "~/lib/igdb/client";
 export type { GameData };
 
 /**
- * Server action for fetching games from IGDB with caching
- * This provides an additional caching layer on top of fetch-level caching
- * The timestamp is passed as a parameter to make it part of the cache key
+ * Server-side data helper for fetching games from IGDB with caching
  */
 export const fetchGames = async (
   c: Consoles,

--- a/src/app/[console]/[type]/navigation.tsx
+++ b/src/app/[console]/[type]/navigation.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { CONSOLES, Consoles, TYPES, Types } from "~/data/constants";
 
 export default function Navigation({
@@ -9,9 +10,15 @@ export default function Navigation({
   selectedConsole: Consoles;
   selectedType: Types;
 }) {
+  const router = useRouter();
+
   const setPreferenceCookies = (console: Consoles, type: Types) => {
     document.cookie = `selectedConsole=${console}; path=/; max-age=31536000; SameSite=Lax`;
     document.cookie = `selectedType=${type}; path=/; max-age=31536000; SameSite=Lax`;
+  };
+
+  const prefetchOnHover = (href: string) => {
+    router.prefetch(href);
   };
 
   return (
@@ -27,8 +34,14 @@ export default function Navigation({
                   className={`hover:underline ${
                     selectedConsole === key ? "underline" : ""
                   }`}
-                  prefetch={true}
+                  prefetch={false}
                   href={`/${key}/${selectedType}`}
+                  onMouseEnter={() => {
+                    prefetchOnHover(`/${key}/${selectedType}`);
+                  }}
+                  onFocus={() => {
+                    prefetchOnHover(`/${key}/${selectedType}`);
+                  }}
                   onClick={() => {
                     setPreferenceCookies(key as Consoles, selectedType);
                   }}
@@ -51,8 +64,14 @@ export default function Navigation({
                   className={`hover:underline ${
                     selectedType === key ? "underline" : ""
                   }`}
-                  prefetch={true}
+                  prefetch={false}
                   href={`/${selectedConsole}/${key}`}
+                  onMouseEnter={() => {
+                    prefetchOnHover(`/${selectedConsole}/${key}`);
+                  }}
+                  onFocus={() => {
+                    prefetchOnHover(`/${selectedConsole}/${key}`);
+                  }}
                   onClick={() => {
                     setPreferenceCookies(selectedConsole, key as Types);
                   }}

--- a/src/app/[console]/[type]/navigation.tsx
+++ b/src/app/[console]/[type]/navigation.tsx
@@ -1,6 +1,5 @@
 "use client";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { CONSOLES, Consoles, TYPES, Types } from "~/data/constants";
 
 export default function Navigation({
@@ -10,15 +9,9 @@ export default function Navigation({
   selectedConsole: Consoles;
   selectedType: Types;
 }) {
-  const router = useRouter();
-
   const setPreferenceCookies = (console: Consoles, type: Types) => {
     document.cookie = `selectedConsole=${console}; path=/; max-age=31536000; SameSite=Lax`;
     document.cookie = `selectedType=${type}; path=/; max-age=31536000; SameSite=Lax`;
-  };
-
-  const prefetchOnHover = (href: string) => {
-    router.prefetch(href);
   };
 
   return (
@@ -34,14 +27,8 @@ export default function Navigation({
                   className={`hover:underline ${
                     selectedConsole === key ? "underline" : ""
                   }`}
-                  prefetch={false}
+                  prefetch="auto"
                   href={`/${key}/${selectedType}`}
-                  onMouseEnter={() => {
-                    prefetchOnHover(`/${key}/${selectedType}`);
-                  }}
-                  onFocus={() => {
-                    prefetchOnHover(`/${key}/${selectedType}`);
-                  }}
                   onClick={() => {
                     setPreferenceCookies(key as Consoles, selectedType);
                   }}
@@ -64,14 +51,8 @@ export default function Navigation({
                   className={`hover:underline ${
                     selectedType === key ? "underline" : ""
                   }`}
-                  prefetch={false}
+                  prefetch="auto"
                   href={`/${selectedConsole}/${key}`}
-                  onMouseEnter={() => {
-                    prefetchOnHover(`/${selectedConsole}/${key}`);
-                  }}
-                  onFocus={() => {
-                    prefetchOnHover(`/${selectedConsole}/${key}`);
-                  }}
                   onClick={() => {
                     setPreferenceCookies(selectedConsole, key as Types);
                   }}

--- a/src/app/[console]/[type]/page.tsx
+++ b/src/app/[console]/[type]/page.tsx
@@ -1,8 +1,10 @@
 import { cacheLife, cacheTag } from "next/cache";
+import { Suspense } from "react";
 import { Consoles, Types, CONSOLES, TYPES } from "~/data/constants";
 import { fetchGames } from "./actions";
 import { GameListItem } from "./components/GameListItem";
 import { dateToRelative } from "~/lib/utils/date";
+import Loading from "./loading";
 
 // Generate static params for all console/type combinations
 // This tells Next.js to prerender these routes at build time
@@ -18,17 +20,14 @@ export function generateStaticParams() {
   );
 }
 
-export default async function ListPage(props: {
-  params: Promise<{
-    console: string;
-    type: string;
-  }>;
+async function GamesList({
+  selectedConsole,
+  selectedType,
+}: {
+  selectedConsole: Consoles;
+  selectedType: Types;
 }) {
   "use cache";
-
-  const params = await props.params;
-  const selectedConsole = params.console as Consoles;
-  const selectedType = params.type as Types;
 
   cacheLife("hours");
   cacheTag(`list-${selectedConsole}-${selectedType}`);
@@ -53,5 +52,26 @@ export default async function ListPage(props: {
         />
       ))}
     </ul>
+  );
+}
+
+export default async function ListPage(props: {
+  params: Promise<{
+    console: string;
+    type: string;
+  }>;
+}) {
+  const params = await props.params;
+  const selectedConsole = params.console as Consoles;
+  const selectedType = params.type as Types;
+
+  return (
+    <Suspense fallback={<Loading />}>
+      <GamesList
+        key={`${selectedConsole}-${selectedType}`}
+        selectedConsole={selectedConsole}
+        selectedType={selectedType}
+      />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- render the games list inside `Suspense` with the route `loading` UI as fallback so cold transitions show a skeleton instead of waiting on a blank state
- move list fetching into a cached `GamesList` server component and keep route param parsing in the page entrypoint
- switch nav links to intent-based prefetch (`router.prefetch` on hover/focus) to avoid immediate link prefetching while preserving quick interactions